### PR TITLE
Match sqllogictest bugs behavior as well

### DIFF
--- a/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/dbsp/circuit/DBSPCircuit.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/dbsp/circuit/DBSPCircuit.java
@@ -29,6 +29,7 @@ import org.dbsp.sqlCompiler.dbsp.circuit.operator.DBSPOperator;
 import org.dbsp.sqlCompiler.dbsp.circuit.operator.DBSPSinkOperator;
 import org.dbsp.sqlCompiler.dbsp.circuit.operator.DBSPSourceOperator;
 import org.dbsp.sqlCompiler.dbsp.circuit.type.DBSPType;
+import org.dbsp.sqlCompiler.dbsp.circuit.type.DBSPTypeRawTuple;
 import org.dbsp.sqlCompiler.dbsp.circuit.type.DBSPTypeTuple;
 import org.dbsp.util.IndentStringBuilder;
 import org.dbsp.util.Linq;
@@ -64,6 +65,7 @@ public class DBSPCircuit extends DBSPNode {
             "};\n" +
             "use tuple::declare_tuples;\n" +
             "use sqllibbool::*;\n" +
+            "use sqlvalue::*;\n" +
             "use hashing::*;\n" +
             "type Weight = isize;\n";
 
@@ -134,7 +136,7 @@ public class DBSPCircuit extends DBSPNode {
 
         builder.append("declare_tuples! {").increase();
         // Do not generate Tuple1
-        for (int i = 2; i <= DBSPTypeTuple.maxTupleSize; i++) {
+        for (int i = 1; i <= DBSPTypeTuple.maxTupleSize; i++) {
             builder.append("Tuple")
                     .append(i)
                     .append("<");
@@ -171,7 +173,7 @@ public class DBSPCircuit extends DBSPNode {
             builder.append(i.getNonVoidType());
         }
         builder.append(") -> ");
-        DBSPTypeTuple tuple = new DBSPTypeTuple(null, Linq.map(this.outputOperators, DBSPOperator::getNonVoidType));
+        DBSPTypeTuple tuple = new DBSPTypeRawTuple(null, Linq.map(this.outputOperators, DBSPOperator::getNonVoidType));
         builder.append(tuple)
                 .append(" {")
                 .increase();

--- a/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/dbsp/circuit/SqlRuntimeLibrary.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/dbsp/circuit/SqlRuntimeLibrary.java
@@ -274,6 +274,7 @@ public class SqlRuntimeLibrary {
                                     type);
                         }
                         DBSPFunction func = new DBSPFunction(function.function, Arrays.asList(left, right), type, def);
+                        func.addAnnotation("#[inline(always)]");
                         declarations.add(func);
                     }
                 }

--- a/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/dbsp/circuit/expression/DBSPApplyExpression.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/dbsp/circuit/expression/DBSPApplyExpression.java
@@ -26,6 +26,7 @@
 package org.dbsp.sqlCompiler.dbsp.circuit.expression;
 
 import org.dbsp.sqlCompiler.dbsp.circuit.type.DBSPType;
+import org.dbsp.sqlCompiler.dbsp.circuit.type.DBSPTypeAny;
 import org.dbsp.util.IndentStringBuilder;
 
 import javax.annotation.Nullable;
@@ -34,10 +35,16 @@ import javax.annotation.Nullable;
  * Function application expression.
  */
 public class DBSPApplyExpression extends DBSPExpression {
-    public final String function;
+    public final DBSPExpression function;
     public final DBSPExpression[] arguments;
 
     public DBSPApplyExpression(String function, @Nullable DBSPType returnType, DBSPExpression... arguments) {
+        super(null, returnType);
+        this.function = new DBSPVariableReference(function, DBSPTypeAny.instance);
+        this.arguments = arguments;
+    }
+
+    public DBSPApplyExpression(DBSPExpression function, @Nullable DBSPType returnType, DBSPExpression... arguments) {
         super(null, returnType);
         this.function = function;
         this.arguments = arguments;

--- a/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/dbsp/circuit/expression/DBSPFunction.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/dbsp/circuit/expression/DBSPFunction.java
@@ -32,6 +32,7 @@ import org.dbsp.sqlCompiler.dbsp.circuit.type.IHasType;
 import org.dbsp.util.IndentStringBuilder;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -67,6 +68,7 @@ public class DBSPFunction extends DBSPNode implements IDBSPDeclaration {
     @Nullable
     public final DBSPType returnType;
     public final DBSPExpression body;
+    public final List<String> annotations;
 
     public DBSPFunction(String name, List<DBSPArgument> arguments, @Nullable DBSPType returnType, DBSPExpression body) {
         super(null);
@@ -74,11 +76,17 @@ public class DBSPFunction extends DBSPNode implements IDBSPDeclaration {
         this.arguments = arguments;
         this.returnType = returnType;
         this.body = body;
+        this.annotations = new ArrayList<>();
+    }
+
+    public void addAnnotation(String annotation) {
+        this.annotations.add(annotation);
     }
 
     @Override
     public IndentStringBuilder toRustString(IndentStringBuilder builder) {
-        builder.append("pub fn ")
+        builder.intercalateS("\n", this.annotations)
+                .append("pub fn ")
                 .append(this.name)
                 .append("(")
                 .join(", ", this.arguments)

--- a/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/dbsp/circuit/expression/DBSPQualifyTypeExpression.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/dbsp/circuit/expression/DBSPQualifyTypeExpression.java
@@ -23,21 +23,27 @@
 
 package org.dbsp.sqlCompiler.dbsp.circuit.expression;
 
-import org.dbsp.sqlCompiler.dbsp.circuit.DBSPNode;
+import org.dbsp.sqlCompiler.dbsp.circuit.type.DBSPType;
 import org.dbsp.util.IndentStringBuilder;
 
-public class DBSPComment extends DBSPExpression {
-    private final String comment;
+/**
+ * An expression qualified with a type.
+ */
+public class DBSPQualifyTypeExpression extends DBSPExpression {
+    public final DBSPExpression expression;
+    public final DBSPType[] type;
 
-    public DBSPComment(String comment) {
-        super(null, null);
-        this.comment = comment;
+    public DBSPQualifyTypeExpression(DBSPExpression expression, DBSPType... type) {
+        super(null, expression.getType());
+        this.expression = expression;
+        this.type = type;
     }
 
     @Override
     public IndentStringBuilder toRustString(IndentStringBuilder builder) {
-        return builder.append("//")
-                .append(comment)
-                .append("\n");
+        return builder.append(this.expression)
+                .append("::<")
+                .join(", ", this.type)
+                .append(">");
     }
 }

--- a/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/dbsp/circuit/expression/DBSPTupleExpression.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/dbsp/circuit/expression/DBSPTupleExpression.java
@@ -89,14 +89,12 @@ public class DBSPTupleExpression extends DBSPExpression {
     public IndentStringBuilder toRustString(IndentStringBuilder builder) {
         if (this.fields.isEmpty()) {
             return builder.append("()");
-        } else if (this.fields.size() != 1)
+        } else {
             return builder.append("Tuple")
                     .append(this.fields.size())
                     .append("::new(")
                     .join(", ", this.fields)
                     .append(")");
-        else {
-            return builder.append(this.fields.get(0));
         }
     }
 }

--- a/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/dbsp/circuit/type/DBSPTypeTuple.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/dbsp/circuit/type/DBSPTypeTuple.java
@@ -63,9 +63,7 @@ public class DBSPTypeTuple extends DBSPType {
 
     @Override
     public IndentStringBuilder toRustString(IndentStringBuilder builder) {
-        if (this.tupArgs.length == 1)
-            return builder.append(this.tupArgs[0]);
-        else if (this.tupArgs.length == 0)
+        if (this.tupArgs.length == 0)
             return builder.append("()");
         builder.append("Tuple")
                 .append(this.tupArgs.length)

--- a/SQL-compiler/src/main/java/org/dbsp/sqllogictest/DBSPExecutor.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqllogictest/DBSPExecutor.java
@@ -66,7 +66,7 @@ public class DBSPExecutor implements ISqlTestExecutor {
         }
     }
 
-    private final boolean debug = false;
+    private final boolean debug = true;
     static final String rustDirectory = "../temp";
     static final String testFilePath = rustDirectory + "/src/test.rs";
     int queryNo;

--- a/SQL-compiler/src/main/java/org/dbsp/sqllogictest/DBSPExecutor.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqllogictest/DBSPExecutor.java
@@ -179,7 +179,7 @@ public class DBSPExecutor implements ISqlTestExecutor {
         String rust = dbsp.toRustString();
         DBSPFunction func = SqlRuntimeLibrary.createTesterCode(
                 "tester" + this.queryNo, inputFunctionName,
-                dbsp, expectedOutput, output.getExpectedOutputSize(), output.hash, output.order);
+                dbsp, expectedOutput, output);
         this.queries.add(new ProgramAndTester(rust, func));
         this.queryNo++;
     }

--- a/SQL-compiler/src/main/java/org/dbsp/sqllogictest/Main.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqllogictest/Main.java
@@ -53,7 +53,7 @@ public class Main {
         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
             String extension = Utilities.getFileExtension(file.toString());
             String str = file.toString();
-            if (str.contains("slt_good_12.") || str.contains("slt_good_53."))
+            if (str.contains("slt_good_12."))
                 return FileVisitResult.CONTINUE;
             if (attrs.isRegularFile() && extension != null && extension.equals("test")) {
                 // validates the test

--- a/SQL-compiler/src/main/java/org/dbsp/sqllogictest/Main.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqllogictest/Main.java
@@ -37,7 +37,7 @@ import java.util.List;
  * Execute all SqlLogicTest tests.
  */
 public class Main {
-    static String[] done = { "10", "62", "12", "53", "126" };
+    static String[] done = { "10", "62", "12", "53", "126", "46", "51", "65", "67", "74", "0" };
 
     static class NoMySql implements TestAcceptancePolicy {
         @Override
@@ -56,7 +56,7 @@ public class Main {
             String extension = Utilities.getFileExtension(file.toString());
             String str = file.toString();
             for (String d: done)
-                if (str.contains("_" + d + "."))
+                if (str.contains("select/slt_good_" + d + "."))
                     return FileVisitResult.CONTINUE;
             if (attrs.isRegularFile() && extension != null && extension.equals("test")) {
                 // validates the test

--- a/SQL-compiler/src/main/java/org/dbsp/sqllogictest/Main.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqllogictest/Main.java
@@ -37,6 +37,8 @@ import java.util.List;
  * Execute all SqlLogicTest tests.
  */
 public class Main {
+    static String[] done = { "10", "62", "12", "53", "126" };
+
     static class NoMySql implements TestAcceptancePolicy {
         @Override
         public boolean accept(List<String> skip, List<String> only) {
@@ -53,8 +55,9 @@ public class Main {
         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
             String extension = Utilities.getFileExtension(file.toString());
             String str = file.toString();
-            if (str.contains("slt_good_12."))
-                return FileVisitResult.CONTINUE;
+            for (String d: done)
+                if (str.contains("_" + d + "."))
+                    return FileVisitResult.CONTINUE;
             if (attrs.isRegularFile() && extension != null && extension.equals("test")) {
                 // validates the test
                 SqlTestFile test = null;
@@ -76,8 +79,8 @@ public class Main {
                     }
                 }
             }
-            return FileVisitResult.TERMINATE;
-            //return FileVisitResult.CONTINUE;
+            //return FileVisitResult.TERMINATE;
+            return FileVisitResult.CONTINUE;
         }
     }
 

--- a/SQL-compiler/src/main/java/org/dbsp/sqllogictest/SqlTestFile.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqllogictest/SqlTestFile.java
@@ -266,7 +266,7 @@ public class SqlTestFile {
     }
 
     void execute(ISqlTestExecutor executor) throws SqlParseException, IOException, InterruptedException {
-        int batchSize = 500;
+        int batchSize = 10;
         executor.reset();
         int i = 0;
         for (SqlTestQuery testQuery : this.tests) {
@@ -274,13 +274,11 @@ public class SqlTestFile {
             executor.addQuery(testQuery.query, this.prepareInput, testQuery.outputDescription);
             i++;
             if (i % batchSize == 0) {
-                if (true || i > 6000) {
-                    System.out.println("Executing up to " + i);
-                    long start = System.nanoTime();
-                    executor.run();
-                    long end = System.nanoTime();
-                    System.out.println("This took " + (end - start) / 1000000000 + " seconds");
-                }
+                System.out.println("Executing up to " + i);
+                long start = System.nanoTime();
+                executor.run();
+                long end = System.nanoTime();
+                System.out.println("This took " + (end - start) / 1000000000 + " seconds");
                 executor.reset();
             }
         }

--- a/SQL-compiler/src/main/java/org/dbsp/sqllogictest/SqlTestOutputDescription.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqllogictest/SqlTestOutputDescription.java
@@ -122,7 +122,12 @@ public class SqlTestOutputDescription {
         this.valueCount = values;
     }
 
+    /**
+     * Return -1 if the output size is not known.
+     */
     public int getExpectedOutputSize() {
-        return this.valueCount / Objects.requireNonNull(this.columnTypes).length();
+        if (this.columnTypes == null || this.valueCount < 0)
+            return -1;
+        return this.valueCount / this.columnTypes.length();
     }
 }

--- a/SQL-compiler/src/main/java/org/dbsp/util/IndentStringBuilder.java
+++ b/SQL-compiler/src/main/java/org/dbsp/util/IndentStringBuilder.java
@@ -109,6 +109,14 @@ public class IndentStringBuilder {
         return this;
     }
 
+    public IndentStringBuilder intercalateS(String separator, List<String> data) {
+        for (String d: data) {
+            this.append(d);
+            this.append(separator);
+        }
+        return this;
+    }
+
     public IndentStringBuilder newline() {
         return this.append("\n");
     }

--- a/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/EndToEndTests.java
+++ b/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/EndToEndTests.java
@@ -88,10 +88,12 @@ public class EndToEndTests {
         transaction.addSet("T", input);
         DBSPFunction inputGen = transaction.inputGeneratingFunction("input", circuit);
         writer.println(inputGen.toRustString());
+        SqlTestOutputDescription description = new SqlTestOutputDescription();
+        description.columnTypes = "I";
+        description.setValueCount(expectedOutput.size());
         DBSPFunction tester = SqlRuntimeLibrary.createTesterCode(
                 "tester", "input",
-                circuit, expectedOutput, expectedOutput.size(), null,
-                SqlTestOutputDescription.SortOrder.None);
+                circuit, expectedOutput, description);
         writer.println("#[test]");
         writer.println(tester.toRustString());
     }

--- a/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/EndToEndTests.java
+++ b/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/EndToEndTests.java
@@ -6,8 +6,7 @@ import org.dbsp.sqlCompiler.dbsp.DBSPTransaction;
 import org.dbsp.sqlCompiler.dbsp.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.dbsp.circuit.SqlRuntimeLibrary;
 import org.dbsp.sqlCompiler.dbsp.circuit.expression.*;
-import org.dbsp.sqlCompiler.dbsp.circuit.type.DBSPTypeDouble;
-import org.dbsp.sqlCompiler.dbsp.circuit.type.DBSPTypeInteger;
+import org.dbsp.sqlCompiler.dbsp.circuit.type.*;
 import org.dbsp.sqlCompiler.frontend.CalciteCompiler;
 import org.dbsp.sqlCompiler.frontend.CalciteProgram;
 import org.dbsp.sqllogictest.SqlTestOutputDescription;
@@ -15,7 +14,6 @@ import org.dbsp.util.Utilities;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.annotation.Nullable;
 import java.io.*;
 
 /**
@@ -82,6 +80,21 @@ public class EndToEndTests {
         return new DBSPZSetLiteral(CalciteToDBSPCompiler.weightType, e0, e1);
     }
 
+    @SuppressWarnings("unused")
+    private String getStringFormat(DBSPTypeTuple type) {
+        StringBuilder result = new StringBuilder();
+        for (DBSPType field: type.tupArgs) {
+            if (field.is(DBSPTypeInteger.class))
+                result.append("I");
+            else if (field.is(DBSPTypeFP.class))
+                result.append("R");
+            else if (field.is(DBSPTypeString.class))
+                result.append("T");
+            else result.append("T");
+        }
+        return result.toString();
+    }
+
     private void createTester(PrintWriter writer, DBSPCircuit circuit, DBSPZSetLiteral expectedOutput) {
         DBSPZSetLiteral input = this.createInput();
         DBSPTransaction transaction = new DBSPTransaction();
@@ -89,8 +102,9 @@ public class EndToEndTests {
         DBSPFunction inputGen = transaction.inputGeneratingFunction("input", circuit);
         writer.println(inputGen.toRustString());
         SqlTestOutputDescription description = new SqlTestOutputDescription();
-        description.columnTypes = "I";
+        description.columnTypes = null;
         description.setValueCount(expectedOutput.size());
+        description.order = SqlTestOutputDescription.SortOrder.Row;
         DBSPFunction tester = SqlRuntimeLibrary.createTesterCode(
                 "tester", "input",
                 circuit, expectedOutput, description);
@@ -98,7 +112,7 @@ public class EndToEndTests {
         writer.println(tester.toRustString());
     }
 
-    private void testQuery(String query, @Nullable DBSPZSetLiteral expectedOutput) {
+    private void testQuery(String query, DBSPZSetLiteral expectedOutput) {
         try {
             DBSPCircuit circuit = this.compileQuery(query);
             PrintWriter writer = new PrintWriter(testFilePath, "UTF-8");

--- a/lib/hashing/Cargo.toml
+++ b/lib/hashing/Cargo.toml
@@ -3,8 +3,7 @@ name = "hashing"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 md5 = { version = "0.7.0" }
 dbsp = { git = "https://github.com/vmware/database-stream-processor.git" }
+sqlvalue = { path = "../sqlvalue" }

--- a/lib/sqllibbool/src/lib.rs
+++ b/lib/sqllibbool/src/lib.rs
@@ -1,10 +1,12 @@
 #![allow(non_snake_case)]
 
+#[inline(always)]
 pub fn or_b_b(left: bool, right: bool) -> bool
 {
     left || right
 }
 
+#[inline(always)]
 pub fn or_bN_b(left: Option<bool>, right: bool) -> Option<bool>
 {
     match (left, right) {
@@ -14,6 +16,7 @@ pub fn or_bN_b(left: Option<bool>, right: bool) -> Option<bool>
     }
 }
 
+#[inline(always)]
 pub fn or_b_bN(left: bool, right: Option<bool>) -> Option<bool>
 {
     match (left, right) {
@@ -23,6 +26,7 @@ pub fn or_b_bN(left: bool, right: Option<bool>) -> Option<bool>
     }
 }
 
+#[inline(always)]
 pub fn or_bN_bN(left: Option<bool>, right: Option<bool>) -> Option<bool>
 {
     match (left, right) {
@@ -33,11 +37,13 @@ pub fn or_bN_bN(left: Option<bool>, right: Option<bool>) -> Option<bool>
     }
 }
 
+#[inline(always)]
 pub fn and_b_b(left: bool, right: bool) -> bool
 {
     left && right
 }
 
+#[inline(always)]
 pub fn and_bN_b(left: Option<bool>, right: bool) -> Option<bool>
 {
     match (left, right) {
@@ -47,6 +53,7 @@ pub fn and_bN_b(left: Option<bool>, right: bool) -> Option<bool>
     }
 }
 
+#[inline(always)]
 pub fn and_b_bN(left: bool, right: Option<bool>) -> Option<bool>
 {
     match (left, right) {
@@ -56,6 +63,7 @@ pub fn and_b_bN(left: bool, right: Option<bool>) -> Option<bool>
     }
 }
 
+#[inline(always)]
 pub fn and_bN_bN(left: Option<bool>, right: Option<bool>) -> Option<bool>
 {
     match (left, right) {
@@ -63,5 +71,14 @@ pub fn and_bN_bN(left: Option<bool>, right: Option<bool>) -> Option<bool>
         (Some(false), _) => Some(false),
         (_, Some(false)) => Some(false),
         (_, _) => None::<bool>,
+    }
+}
+
+#[inline(always)]
+pub fn is_null<T>(value: Option<T>) -> bool
+{
+    match value {
+        Some(_) => false,
+        _       => true,
     }
 }

--- a/lib/sqlvalue/Cargo.toml
+++ b/lib/sqlvalue/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "sqlvalue"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ordered-float = { version = "2.0.0" }

--- a/lib/sqlvalue/src/lib.rs
+++ b/lib/sqlvalue/src/lib.rs
@@ -1,0 +1,192 @@
+// SqlValue is a dynamically-typed object that holds a value that at
+// runtime can appear in a SQL program.  These values are not used
+// during computations, but they are used to display values.  The
+// Tuple* types are used for computations, and they are converted
+// to SqlRow objects when they need to be displayed.
+
+use ordered_float::OrderedFloat;
+
+pub enum SqlValue {
+    Int(i32),
+    Str(String),
+    Flt(f32),
+    Dbl(f64),
+    Bool(bool),
+
+    OptInt(Option<i32>),
+    OptStr(Option<String>),
+    OptFlt(Option<f32>),
+    OptDbl(Option<f64>),
+    OptBool(Option<bool>),
+}
+
+impl From<i32> for SqlValue {
+    fn from(value: i32) -> Self {
+        SqlValue::Int(value)
+    }
+}
+
+impl From<f32> for SqlValue {
+    fn from(value: f32) -> Self {
+        SqlValue::Flt(value)
+    }
+}
+
+impl From<f64> for SqlValue {
+    fn from(value: f64) -> Self {
+        SqlValue::Dbl(value)
+    }
+}
+
+impl From<OrderedFloat<f32>> for SqlValue {
+    fn from(value: OrderedFloat<f32>) -> Self {
+        SqlValue::Flt(value.into())
+    }
+}
+
+impl From<OrderedFloat<f64>> for SqlValue {
+    fn from(value: OrderedFloat<f64>) -> Self {
+        SqlValue::Dbl(value.into())
+    }
+}
+
+impl From<String> for SqlValue {
+    fn from(value: String) -> Self {
+        SqlValue::Str(value)
+    }
+}
+
+impl From<Option<i32>> for SqlValue {
+    fn from(value: Option<i32>) -> Self {
+        SqlValue::OptInt(value)
+    }
+}
+
+impl From<Option<f32>> for SqlValue {
+    fn from(value: Option<f32>) -> Self {
+        SqlValue::OptFlt(value)
+    }
+}
+
+impl From<Option<f64>> for SqlValue {
+    fn from(value: Option<f64>) -> Self {
+        SqlValue::OptDbl(value)
+    }
+}
+
+impl From<Option<OrderedFloat<f32>>> for SqlValue {
+    fn from(value: Option<OrderedFloat<f32>>) -> Self {
+        match value {
+            None => SqlValue::OptFlt(None),
+            Some(OrderedFloat(x)) => SqlValue::OptFlt(Some(x)),
+        }
+    }
+}
+
+impl From<Option<OrderedFloat<f64>>> for SqlValue {
+    fn from(value: Option<OrderedFloat<f64>>) -> Self {
+        match value {
+            None => SqlValue::OptDbl(None),
+            Some(OrderedFloat(x)) => SqlValue::OptDbl(Some(x)),
+        }
+    }
+}
+
+impl From<Option<String>> for SqlValue {
+    fn from(value: Option<String>) -> Self {
+        SqlValue::OptStr(value)
+    }
+}
+
+pub struct SqlRow {
+    values: Vec<SqlValue>,
+}
+
+pub trait ToSqlRow {
+    fn to_row(&self) -> SqlRow;
+}
+
+impl SqlRow {
+    pub fn new() -> Self {
+        SqlRow { values: Vec::default() }
+    }
+
+    // Output the SqlRow value in the format expected by the tests
+    // in SqlLogicTest.
+    // 'format' is a string with characters I, R, or T, standing
+    // respectively for integers, real, or text.
+    pub fn to_slt_strings(self, format: &String) -> Vec<String> {
+        if self.values.len() != format.len() {
+            panic!("Mismatched format {} vs len {}", format.len(), self.values.len())
+        }
+        let mut result = Vec::<String>::new();
+        for elem in self.values.iter().zip(format.chars()) {
+            result.push(elem.0.format_slt(&elem.1));
+        }
+        result
+    }
+}
+
+impl SqlRow {
+    pub fn push(self: &mut Self, value: SqlValue) {
+        self.values.push(value)
+    }
+}
+
+impl Default for SqlRow {
+    fn default() -> Self {
+        SqlRow { values: Vec::default() }
+    }
+}
+
+pub trait SqlLogicTestFormat {
+    fn format_slt(&self, arg: &char) -> String;
+}
+
+
+fn print_string(s: &String) -> String {
+    if s == "" {
+        return String::from("(empty)")
+    }
+    let mut result = String::new();
+    for mut c in s.chars() {
+        if c < ' ' || c > '~' {
+            c = '@';
+        }
+        result.push(c);
+    }
+    result
+}
+
+// Format a SqlValue according to SqlLogicTest rules
+// the arg is one character of the form I - i32, R - f32, or T - String.
+impl SqlLogicTestFormat for SqlValue {
+    fn format_slt(self: &Self, arg: &char) -> String {
+        match (self, arg) {
+            (SqlValue::Int(x), _) => format!("{}", x),
+            (SqlValue::OptInt(None), _) => String::from("NULL"),
+            (SqlValue::OptInt(Some(x)), _) => format!("{}", x),
+
+            (SqlValue::OptFlt(None), _) => String::from("NULL"),
+            (SqlValue::Flt(x), 'I') => format!("{}", *x as i32),
+            (SqlValue::OptFlt(Some(x)), 'I') => format!("{}", *x as i32),
+            (SqlValue::Flt(x), _) => format!("{:.3}", x),
+            (SqlValue::OptFlt(Some(x)), _) => format!("{:.3}", x),
+
+            (SqlValue::OptDbl(None), _) => String::from("NULL"),
+            (SqlValue::Dbl(x), 'I') => format!("{}", *x as i32),
+            (SqlValue::OptDbl(Some(x)), 'I') => format!("{}", *x as i32),
+            (SqlValue::Dbl(x), _) => format!("{:.3}", x),
+            (SqlValue::OptDbl(Some(x)), _) => format!("{:.3}", x),
+
+            (SqlValue::Str(x), 'T') => print_string(x),
+            (SqlValue::OptStr(None), 'T') => String::from("NULL"),
+            (SqlValue::OptStr(Some(x)), 'T') => print_string(x),
+
+            (SqlValue::OptBool(None), _) => String::from("NULL"),
+            (SqlValue::Bool(b), _) => format!("{}", b),
+            (SqlValue::OptBool(Some(b)), _) => format!("{}", b),
+            _ => panic!("Unexpected combination"),
+        }
+    }
+}

--- a/lib/sqlvalue/src/lib.rs
+++ b/lib/sqlvalue/src/lib.rs
@@ -26,6 +26,12 @@ impl From<i32> for SqlValue {
     }
 }
 
+impl From<bool> for SqlValue {
+    fn from(value: bool) -> Self {
+        SqlValue::Bool(value)
+    }
+}
+
 impl From<f32> for SqlValue {
     fn from(value: f32) -> Self {
         SqlValue::Flt(value)
@@ -59,6 +65,12 @@ impl From<String> for SqlValue {
 impl From<Option<i32>> for SqlValue {
     fn from(value: Option<i32>) -> Self {
         SqlValue::OptInt(value)
+    }
+}
+
+impl From<Option<bool>> for SqlValue {
+    fn from(value: Option<bool>) -> Self {
+        SqlValue::OptBool(value)
     }
 }
 

--- a/lib/tuple/Cargo.toml
+++ b/lib/tuple/Cargo.toml
@@ -3,7 +3,6 @@ name = "tuple"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+sqlvalue = { path = "../sqlvalue" }

--- a/lib/tuple/src/lib.rs
+++ b/lib/tuple/src/lib.rs
@@ -12,9 +12,24 @@ macro_rules! declare_tuples {
             #[derive(Default, Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize)]
             pub struct $tuple_name<$($element,)*>($(pub $element,)*);
 
-            impl<$($element),*> $tuple_name<$($element,)*> {
+            impl<$($element),*> $tuple_name<$($element,)*>
+            {
                 fn new($($element: $element),*) -> Self {
                     Self($($element),*)
+                }
+            }
+
+            impl<$($element),*> ToSqlRow for $tuple_name<$($element,)*>
+            where
+                $(SqlValue: From<$element>,)*
+                $($element: Clone,)*
+            {
+                fn to_row(&self) -> SqlRow
+                {
+                    let mut result = SqlRow::new();
+                    let $tuple_name($($element),*) = self;
+                    $(result.push(SqlValue::from($element.clone()));)*
+                    result
                 }
             }
 

--- a/temp/Cargo.toml
+++ b/temp/Cargo.toml
@@ -10,6 +10,7 @@ dbsp = { git = "https://github.com/vmware/database-stream-processor.git" }
 
 tuple = { path = "../lib/tuple" }
 sqllibbool = { path = "../lib/sqllibbool" }
+sqlvalue = { path = "../lib/sqlvalue" }
 ordered-float = { version = "2.0.0" }
 serde = { version = "1.0", features = ["derive"] }
 hashing = { path = "../lib/hashing" }


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
In particular, SQLLogicTest sometimes also tests the ODBC driver behavior, not just the query computation behavior.
This happens in queries where the output result type is specified to be different than the one actually produced by the query.