### PR TITLE
Fix compilation errors due to missing serde derives for dbsp::algebra::F64

### DIFF
--- a/lib/sqllib/Cargo.toml
+++ b/lib/sqllib/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dbsp = { git = "https://github.com/vmware/database-stream-processor.git", default-features=false }
+dbsp = { git = "https://github.com/vmware/database-stream-processor.git" }
 #dbsp = { path = "../../../database-stream-processor.git" }
 rust_decimal = { version = "1.26" }
 rust_decimal_macros = { version = "1.26" }


### PR DESCRIPTION
Without this fix, I was getting the following compilation errors when building `lib/sqllib`

```
error[E0277]: the trait bound `dbsp::algebra::F64: geopoint::_::_serde::Serialize` is not satisfied
    --> src/geopoint.rs:9:72
     |
9    | #[derive(Default, Eq, Ord, Clone, Hash, PartialEq, PartialOrd, SizeOf, Serialize, Deserialize, Debug)]
     |                                                                        ^^^^^^^^^ the trait `geopoint::_::_serde::Serialize` is not implemented for `dbsp::algebra::F64`
10   | pub struct GeoPoint(F64, F64);
     |                     --- required by a bound introduced by this call
     |
     = help: the following other types implement trait `geopoint::_::_serde::Serialize`:
               &'a T
               &'a mut T
               ()
               (T0, T1)
               (T0, T1, T2)
               (T0, T1, T2, T3)
               (T0, T1, T2, T3, T4)
               (T0, T1, T2, T3, T4, T5)
             and 130 others
note: required by a bound in `geopoint::_::_serde::ser::SerializeTupleStruct::serialize_field`
    --> /Users/lsuresh/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.152/src/ser/mod.rs:1679:12
     |
1679 |         T: Serialize;
     |            ^^^^^^^^^ required by this bound in `geopoint::_::_serde::ser::SerializeTupleStruct::serialize_field`

error[E0277]: the trait bound `dbsp::algebra::F64: geopoint::_::_serde::Deserialize<'_>` is not satisfied
    --> src/geopoint.rs:10:21
     |
10   | pub struct GeoPoint(F64, F64);
     |                     ^^^ the trait `geopoint::_::_serde::Deserialize<'_>` is not implemented for `dbsp::algebra::F64`
     |
     = help: the following other types implement trait `geopoint::_::_serde::Deserialize<'de>`:
               &'a Path
               &'a [u8]
               &'a str
               ()
               (T0, T1)
               (T0, T1, T2)
               (T0, T1, T2, T3)
               (T0, T1, T2, T3, T4)
             and 130 others
note: required by a bound in `next_element`
    --> /Users/lsuresh/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.152/src/de/mod.rs:1729:12
     |
1729 |         T: Deserialize<'de>,
     |            ^^^^^^^^^^^^^^^^ required by this bound in `next_element`

error[E0277]: the trait bound `dbsp::algebra::F64: geopoint::_::_serde::Deserialize<'_>` is not satisfied
    --> src/geopoint.rs:10:26
     |
10   | pub struct GeoPoint(F64, F64);
     |                          ^^^ the trait `geopoint::_::_serde::Deserialize<'_>` is not implemented for `dbsp::algebra::F64`
     |
     = help: the following other types implement trait `geopoint::_::_serde::Deserialize<'de>`:
               &'a Path
               &'a [u8]
               &'a str
               ()
               (T0, T1)
               (T0, T1, T2)
               (T0, T1, T2, T3)
               (T0, T1, T2, T3, T4)
             and 130 others
note: required by a bound in `next_element`
    --> /Users/lsuresh/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.152/src/de/mod.rs:1729:12
     |
1729 |         T: Deserialize<'de>,
     |            ^^^^^^^^^^^^^^^^ required by this bound in `next_element`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `sqllib` due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
```

Signed-off-by: Lalith Suresh <lsuresh@vmware.com>