### PR TITLE
Fix type mismatch in assert_eq!() when using weighted_vector_count

### DIFF
--- a/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
@@ -522,7 +522,7 @@ public class DBSPExecutor extends SqlTestExecutor {
             }
             list.add(new DBSPExpressionStatement(
                     new DBSPApplyExpression("assert_eq!", null,
-                            count, new DBSPAsExpression(
+                            new DBSPAsExpression(count, DBSPTypeZSet.defaultWeightType), new DBSPAsExpression(
                                     new DBSPIntegerLiteral(description.getExpectedOutputSize()),
                             DBSPTypeZSet.defaultWeightType))));
         }if (output != null) {


### PR DESCRIPTION
Signed-off-by: Lalith Suresh <lsuresh@vmware.com>