### PR TITLE
Read inputs directly from the database in SQL logic tests

### DIFF
--- a/SQL-compiler/src/main/java/org/dbsp/sqllogictest/Main.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqllogictest/Main.java
@@ -136,8 +136,9 @@ public class Main {
                 "-b", "psqlsltbugs.txt",// list of tests to exclude
                 "-i",                   // incremental (streaming) testing
                 "-d", "psql",           // SQL dialect to use
-                "-u", "user",           // database user name
-                "-p", "password"        // database password
+                "-u", "postgres",       // database user name
+                "-p", "password",       // database password
+                "-l", "db"              // can be csv or db
         };
         if (argv.length > 0) {
             args = argv;

--- a/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
@@ -167,7 +167,7 @@ public class DBSPExecutor extends SqlTestExecutor {
         // Generates a read_table(<conn>, <table_name>, <mapper from |AnyRow| -> Tuple type>) invocation
         DBSPTypeUser sqliteRowType = new DBSPTypeUser(null, "AnyRow", false);
         DBSPVariablePath rowVariable = new DBSPVariablePath("row", sqliteRowType);
-        DBSPTypeTuple tupleType = (DBSPTypeTuple) tableValue.contents.zsetType.elementType;
+        DBSPTypeTuple tupleType = tableValue.contents.zsetType.elementType.to(DBSPTypeTuple.class);
         final List<DBSPExpression> rowGets = new ArrayList<>(tupleType.tupFields.length);
         for (int i = 0; i <  tupleType.tupFields.length; i++) {
             DBSPApplyMethodExpression rowGet =

--- a/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/DBSP_JDBC_Executor.java
+++ b/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/DBSP_JDBC_Executor.java
@@ -51,8 +51,9 @@ public class DBSP_JDBC_Executor extends DBSPExecutor {
      * @param execute If true the tests are executed, otherwise they are only compiled to Rust.
      * @param options Compilation options.
      */
-    public DBSP_JDBC_Executor(JDBCExecutor executor, boolean execute, CompilerOptions options) {
-        super(execute, options);
+    public DBSP_JDBC_Executor(JDBCExecutor executor, boolean execute, CompilerOptions options,
+                              String connectionString) {
+        super(execute, options, connectionString);
         this.statementExecutor = executor;
         this.tablesCreated = new ArrayList<>();
     }

--- a/lib/readers/Cargo.lock
+++ b/lib/readers/Cargo.lock
@@ -233,6 +233,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "bincode"
 version = "2.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +686,27 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -998,6 +1025,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,6 +1201,15 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
  "value-bag",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -1586,6 +1640,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,6 +1864,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,11 +2022,13 @@ checksum = "dcbc16ddba161afc99e14d1713a453747a2b07fc097d2009f4c300ec99286105"
 dependencies = [
  "ahash",
  "atoi",
+ "base64",
  "bitflags",
  "byteorder",
  "bytes",
  "crc",
  "crossbeam-queue",
+ "dirs",
  "dotenvy",
  "either",
  "event-listener",
@@ -1962,15 +2040,22 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
+ "hkdf",
+ "hmac",
  "indexmap",
  "itoa 1.0.5",
  "libc",
  "libsqlite3-sys",
  "log",
+ "md-5",
  "memchr",
  "once_cell",
  "paste",
  "percent-encoding",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha1",
  "sha2",
  "smallvec",
  "sqlformat",
@@ -1978,6 +2063,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "url",
+ "whoami",
 ]
 
 [[package]]
@@ -2025,6 +2111,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -2360,6 +2452,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "whoami"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45dbc71f0cdca27dc261a9bd37ddec174e4a0af2b900b890f378460f745426e3"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/lib/readers/Cargo.toml
+++ b/lib/readers/Cargo.toml
@@ -11,5 +11,5 @@ csv = { version = "1.1" }
 #dbsp = { path = "../../../database-stream-processor.git", features = ["with-serde"] }
 dbsp = { git = "https://github.com/vmware/database-stream-processor.git", features = ["with-serde"], default-features = false }
 size-of = { version = "0.1.1" }
-sqlx = { version = "0.6", features = [ "runtime-async-std-native-tls", "sqlite", "any" ] }
+sqlx = { version = "0.6", features = [ "runtime-async-std-native-tls", "sqlite", "postgres", "any" ] }
 async-std = { version = "1.12.0", features = ["attributes"]}

--- a/lib/readers/src/lib.rs
+++ b/lib/readers/src/lib.rs
@@ -110,7 +110,7 @@ fn csv_test() {
 }
 
 #[async_std::test]
-async fn sql_test() {
+async fn sql_test_sqlite() {
     let conn_str = "sqlite:///tmp/test.db";
     if !sqlx::Sqlite::database_exists(conn_str).await.unwrap() {
         sqlx::Sqlite::create_database(conn_str).await.unwrap();


### PR DESCRIPTION
Optionally use read_db() instead of read_csv() to get inputs for SQL logic tests. Can be configured from SQLLogicTest.Main() using a `-l` flag to set either `csv` or `db` as the input source. The connection string is derived from the user, password and SQL dialect when using "-l db". Only supports and tested against postgres for now.

Signed-off-by: Lalith Suresh <lsuresh@vmware.com>