### PR TITLE
Add a minimal CI infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Java CI
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: ['8', '11']
+
+    name: Tests (Java ${{ matrix.java }})
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up JDK {{ matrix.java }}
+      uses: actions/setup-java@v2
+      with:
+        java-version: ${{ matrix.java }}
+        distribution: 'adopt'
+
+    - name: Install rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        default: true
+
+    - name: Build with Maven
+      run: cd SQL-compiler && mvn --batch-mode package

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Tests](https://github.com/vmware/sql-to-dbsp-compiler/actions/workflows/ci.yml/badge.svg)
+
 # SQL to DBSP compiler
 
 This repository holds the source code for a compiler translating SQL


### PR DESCRIPTION
Currently uses stable rust and runs the build against JDK versions 8 and 11.